### PR TITLE
Fix `/api/categories` not updated when new data is added

### DIFF
--- a/src/app/api/categories/route.js
+++ b/src/app/api/categories/route.js
@@ -4,6 +4,8 @@ import Score from "@/models/Score";
 
 dbConnect();
 
+export const revalidate = 0;
+
 export async function GET() {
   const highScores = await Score.find({ score: { $gt: 79 } }).select("-__v");
   const mediumScores = await Score.find({ score: { $gt: 59, $lt: 79 } }).select(


### PR DESCRIPTION
This PR fixes the `/api/categories` route caching problem resulting to data not updated when new data is added to the database by setting `revalidate` to 0 to make sure Next.js revalidate the cache every 0 seconds instead of the default which is 60 seconds.

This will fix issue #6